### PR TITLE
[PT-275] [HOTFIX] 세특 생성 중 에러 터졌을 때 내용 백엔드에 전달하도록 변경

### DIFF
--- a/app/routers/difficulty_distil.py
+++ b/app/routers/difficulty_distil.py
@@ -33,7 +33,7 @@ router = APIRouter(
 @router.post("/topic")
 async def topic_gen(payload: TopicModel):
     major = payload.major
-    keyword = payload.keyword 
+    keyword = payload.keyword
     seteuk_depth = payload.seteuk_depth
     depth_dict = {'기초': 'Basic', '응용': 'Applied','심화':'Advanced'}
     tp_cs = seteukBasicTopic()
@@ -63,9 +63,20 @@ async def topic_gen(payload: TopicModel):
 @router.post("/guidelines")
 async def protoGenerator(payload: GraphModel):
     major = payload.major
-    keyword = payload.keyword 
+    keyword = payload.keyword
     topic = payload.topic
     seteuk_depth = payload.seteuk_depth
     depth_dict = {'기초': 'Basic', '응용': 'Applied','심화':'Advanced'}
-    response = run(major, keyword, topic, depth_dict[seteuk_depth])
+
+    try:
+        response = run(major, keyword, topic, depth_dict[seteuk_depth])
+    except Exception as e:
+        raise HTTPException(
+            status_code=getattr(e, 'status_code', 500),
+            detail={
+                "error": e.__class__.__name__,
+                "message": str(e)
+            }
+        )
+
     return response


### PR DESCRIPTION
슬랙 에러코드 다음과 같이 뜨게됨

```
    에러이름 : AxiosError
    StatusCode: 500
    요청 URL : /seteuk/auto-guidelines
    에러 메세지 : Request failed with status code 429
    Timestamp : 2025-11-25T04:52:35.992Z
    StackTrace : AxiosError: Request failed with status code 429
    at settle (/Users/arklimits/bearable/bearable-serverless-nestjs/node_modules/axios/lib/core/settle.js:19:12)
    at IncomingMessage.handleStreamEnd (/Users/arklimits/bearable/bearable-serverless-nestjs/node_modules/axios/lib/adapters/http.js:589:11)
    at IncomingMessage.emit (node:events:519:35)
    at endReadableNT (node:internal/streams/readable:1701:12)
    at processTicksAndRejections (node:internal/process/task_queues:90:21)
    at Axios.request (/Users/arklimits/bearable/bearable-serverless-nestjs/node_modules/axios/lib/core/Axios.js:45:41)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
```