### PR TITLE
[PT-1204] [FEAT] dev fastapi를 myfolio-vm Docker로 이전 (Lambda 런타임 제거)

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,10 @@
+.git/
+.venv/
+__pycache__/
+*.pyc
+.env
+.env.*
+.idea/
+.vscode/
+.DS_Store
+claudedocs/

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - dev
       - feat/*
 
 jobs:
@@ -19,13 +18,7 @@ jobs:
       # 2. 환경변수 설정: 브랜치에 따라 ENV와 이미지 태그, API 키들을 설정
       - name: Set Environment Variables
         run: |
-          if [[ "${{ github.ref_name }}" == "dev" ]]; then
-            echo "ENVIRONMENT=development" >> $GITHUB_ENV
-            echo "DOCKER_TAG=dev-${{ github.sha }}" >> $GITHUB_ENV
-            echo "ANTHROPIC_API_KEY=${{ secrets.DEV_ENV_ANTHROPIC }}" >> $GITHUB_ENV
-            echo "PERPLEXITY_API_KEY=${{ secrets.DEV_ENV_PERPLEXITY }}" >> $GITHUB_ENV
-            echo "OPENAI_API_KEY=${{ secrets.DEV_ENV_OPENAI }}" >> $GITHUB_ENV
-          elif [[ "${{ github.ref_name }}" == "main" ]]; then
+          if [[ "${{ github.ref_name }}" == "main" ]]; then
             echo "ENVIRONMENT=production" >> $GITHUB_ENV
             echo "DOCKER_TAG=prod-${{ github.sha }}" >> $GITHUB_ENV
             echo "ANTHROPIC_API_KEY=${{ secrets.PROD_ENV_ANTHROPIC }}" >> $GITHUB_ENV
@@ -83,12 +76,4 @@ jobs:
         run: |
           aws lambda update-function-code \
             --function-name lambdaProtoContainerProd \
-            --image-uri ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/lambda-fastapi:${{ env.DOCKER_TAG }}
-
-      # 8. Lambda 업데이트: dev 브랜치인 경우 development Lambda 업데이트
-      - name: Deploy Development Lambda Function
-        if: ${{ github.ref_name == 'dev' }}
-        run: |
-          aws lambda update-function-code \
-            --function-name lambdaProtoContainerDev \
             --image-uri ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/lambda-fastapi:${{ env.DOCKER_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,18 @@
-FROM python:3.12
+FROM python:3.12-slim
 
-# 작업 디렉토리 설정
 WORKDIR /app
+ENV TZ=Asia/Seoul
 
-# 소스 코드 복사
-COPY app ./app
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    && pip install --upgrade pip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
 COPY fonts ./fonts
 
-# 빌드 시 환경 변수 전달
-ARG ENV= local
-ARG PERPLEXITY_API_KEY
-ARG ANTHROPIC_API_KEY
-ARG OPENAI_API_KEY
-
-# 환경 변수 설정 진행
-ENV ENV=${ENV}
-ENV PERPLEXITY_API_KEY=${PERPLEXITY_API_KEY}
-ENV ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-ENV OPENAI_API_KEY=${OPENAI_API_KEY}
-
-# 의존성 설치
-RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir -r requirements.txt
-
-# 컨테이너 포트 노출
-EXPOSE 8000
-
-RUN echo " 여기 보슈" 
-
-
-# ENV에 따라 실행 명령 변경  
-CMD if [ "$ENV" = local ]; then \
-        uvicorn app.main:app --host 0.0.0.0 --port 8000; \
-    else \
-        python -m awslambdaric app.main.handler; \
-    fi
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY app ./app
 COPY fonts ./fonts
 
+EXPOSE 8080
+
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,6 @@ from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from mangum import Mangum
 
 import sys
 import os
@@ -19,6 +18,3 @@ app.include_router(difficulty_distil.router)
 app.include_router(keyword.router)
 app.include_router(word_cloud.router)
 app.include_router(submission_analyze.router)
-
-# Mangum 객체 생성 (AWS Lambda 호환용)
-handler = Mangum(app)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ annotated-types==0.7.0
 anthropic==0.86.0
 anyio==4.8.0
 attrs==25.1.0
-awslambdaric==3.0.1
 certifi==2024.12.14
 charset-normalizer==3.4.1
 click==8.1.8
@@ -31,7 +30,6 @@ langgraph==0.2.74
 langgraph-checkpoint==2.0.16
 langgraph-sdk==0.1.51
 langsmith==0.2.10
-mangum==0.19.0
 msgpack==1.1.0
 multidict==6.1.0
 numpy==2.2.3


### PR DESCRIPTION
## Summary

- `Dockerfile`을 `python:3.12-slim` + `uvicorn app.main:app --host 0.0.0.0 --port 8080` 으로 교체. AWS Lambda 런타임(`awslambdaric`)과 빌드 인자 시크릿 주입 제거, `EXPOSE 8080` 추가
- `app/main.py`에서 `Mangum` 핸들러 제거
- `requirements.txt`에서 `mangum`, `awslambdaric` 제거
- `.gcloudignore` 추가
- CI(`docker-build.yml`)에서 `dev` 브랜치 트리거 및 dev Lambda 배포 단계 제거 (main→prod Lambda는 유지)

관련: PT-1204 (아이디어)

## Why

dev fastapi LLM 서버를 AWS Lambda에서 GCP로 이전하여 인프라를 일원화한다. dev는 스쿨폴리오/마이폴리오 dev와 동일하게 GCP에서 운영하며, 구체적으로 **myfolio-vm의 Docker 컨테이너**로 배포한다(같은 VM의 NestJS가 `127.0.0.1:8001`로 호출). 이미지는 prod(Cloud Run, 8080)와 동일하게 재사용 가능하도록 포트/런타임을 통일했다.

이전 Dockerfile은 `ENV` 분기로 local=uvicorn / 그 외=awslambdaric 였는데, Cloud Run·Docker 환경에서는 Lambda 런타임이 불필요하고 오히려 포트(8000) 불일치를 유발한다. uvicorn :8080 단일 진입점으로 단순화했다.

## 배포 경로 (repo 밖 — GCP Cloud Build 트리거)

dev 자동배포는 **GitHub Actions가 아니라 GCP Cloud Build 트리거**로 동작한다 (스쿨폴리오/마이폴리오 dev와 동일 방식, repo에는 워크플로 파일 없음). 트리거 설정은 GCP에 인라인으로 저장됨:

- 트리거: `fastapi-dev-deploy` (global, `Team-Bearable/fastapi`, 브랜치 `^dev$`)
- 단계: `docker build` → Artifact Registry push(`asia-northeast3-docker.pkg.dev/praxis-wall-407908/cloud-run-source-deploy/fastapi/myfolio-llm-api:<SHA>`) → **myfolio-vm SSH** → `/opt/myfolio-llm-api`의 `.env` 이미지태그 갱신 + `docker compose up -d`
- 조회: `gcloud builds triggers describe fastapi-dev-deploy --region=global`

### 머지 후 자동배포 확인 방법

```
# 1) 트리거 빌드 상태
gcloud builds list --region=global --filter="substitutions.TRIGGER_NAME=fastapi-dev-deploy" --limit=1
# 2) myfolio-vm 컨테이너가 새 SHA로 갱신/healthy 인지
gcloud compute ssh myfolio-vm --zone=asia-northeast3-b --command="cd /opt/myfolio-llm-api && cat .env && sudo docker ps --filter name=myfolio-llm-api"
# 3) 엔드포인트 응답
gcloud compute ssh myfolio-vm --zone=asia-northeast3-b --command="curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8001/docs"
```

## Behavior preservation

- **API 동작·라우트 동일**: 라우터 10개 경로 모두 그대로 로드(`/keyword-extraction`, `/word-cloud`, `/seteukDifficulty_distil/*` 등). 응답 스키마 변화 없음.
- **시크릿 주입 방식만 변경**: 이미지에 굽던 빌드 인자 → 런타임 env(myfolio-vm은 `secrets/fastapi.env`, prod는 추후 Secret Manager). 앱은 동일하게 `os.getenv`로 읽음.

## Verification

myfolio-vm에서 새 이미지로 컨테이너 기동 후 검증:

| 항목 | 결과 |
|---|---|
| 컨테이너 상태 | `Up (healthy)`, `127.0.0.1:8001->8080` |
| `/docs`, `/openapi.json` | HTTP 200 |
| `/keyword-extraction` 실제 호출 | HTTP 200, 정상 키워드 응답 (LLM 키 동작 확인) |
| nest 컷오버 | `.env.development` `LLM_ENDPOINT=http://127.0.0.1:8001` 변경 + pm2 재시작(2 인스턴스 online) |

## Test plan

- [x] 로컬 `docker build` + 컨테이너 기동 (`/docs` 200, 라우터 10개 로드)
- [x] myfolio-vm 수동 배포 후 `/keyword-extraction` 실호출 200
- [ ] 이 PR 머지 시 `fastapi-dev-deploy` 트리거 자동 빌드→AR→myfolio-vm SSH 배포 정상 동작 확인 (위 "머지 후 자동배포 확인 방법" 참고)
- [ ] 머지 후 dev nest에서 LLM 기능(키워드/워드클라우드) 정상 동작 smoke

## Out of scope

- **prod 이전(Cloud Run)**: 별도 진행. 새 Dockerfile은 Lambda에서 동작하지 않으므로 **prod를 Cloud Run으로 옮기기 전까지 dev→main 머지 금지** (현 워크플로의 main→prod Lambda 경로가 깨진 이미지를 배포함). prod 단계에서 main 경로를 Cloud Run으로 교체 예정.
- **워크플로 build-arg 정리**: line 62-65의 `--build-arg ENV/*_API_KEY`는 새 Dockerfile에 ARG 선언이 없어 무의미(빌드는 경고만). main(prod) 경로를 Cloud Run으로 교체하는 후속 작업에서 함께 정리.
- AWS 리소스(ECR/Lambda dev) 정리

