### PR TITLE
[PT-1213] [REFACTOR] LLM 모델명 model_config로 일원화

### DIFF
--- a/app/routers/difficulty.py
+++ b/app/routers/difficulty.py
@@ -5,7 +5,7 @@ from langchain_core.prompts import ChatPromptTemplate
 import sys
 import os
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-from utils.model import anthropic, gpt4o, gpt4o_mini, perple, perplexity_model
+from utils.model import anthropic, gpt4o, gpt4o_mini, perple, PERPLEXITY_MODEL
 from utils.difficulty_prompt import seteukBasicTopic
 from langchain_core.output_parsers import StrOutputParser
 from fastapi import APIRouter

--- a/app/routers/difficulty_distil.py
+++ b/app/routers/difficulty_distil.py
@@ -7,7 +7,7 @@ import sys, os, ast, re
 from app.routers.proto import parse_json_response
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-from utils.model import anthropic, gpt4o, gpt4o_mini, perple, perplexity_model
+from utils.model import anthropic, gpt4o, gpt4o_mini, perple, PERPLEXITY_MODEL
 from utils.difficulty_prompt_distil2 import seteukBasicTopic
 from langchain_core.output_parsers import StrOutputParser
 from fastapi import APIRouter

--- a/app/routers/proto.py
+++ b/app/routers/proto.py
@@ -5,7 +5,7 @@ from langchain_core.prompts import ChatPromptTemplate
 import sys
 import os
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-from utils.model import anthropic, gpt4o, gpt4o_mini, perple, perplexity_model
+from utils.model import anthropic, gpt4o, gpt4o_mini, perple, PERPLEXITY_MODEL
 from utils.prompt import seteukBasicBodyTop, seteukBasicProto, perplexity_prompt, material_organizer
 from langchain_core.output_parsers import StrOutputParser
 from fastapi import APIRouter
@@ -211,7 +211,7 @@ async def perplexity(payload: RequestModel):
 
     try:
         response = perple.chat.completions.create(
-            model = perplexity_model,
+            model = PERPLEXITY_MODEL,
             messages = perple_messages
         )
         case_result = response.choices[0].message.content

--- a/app/services/difficulty_service/case_researcher.py
+++ b/app/services/difficulty_service/case_researcher.py
@@ -3,7 +3,7 @@ from langchain.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnablePassthrough
 from langchain_core.output_parsers import StrOutputParser
 from utils.difficulty_prompt import  material_organizer, perplexity_prompt
-from utils.model import anthropic, perple, perplexity_model, gpt4o
+from utils.model import anthropic, perple, PERPLEXITY_MODEL, gpt4o
 from utils.utils import perple_process_result
 
 
@@ -38,7 +38,7 @@ def perplexity(state):
     
     try:
         response = perple.chat.completions.create(
-            model = perplexity_model,
+            model = PERPLEXITY_MODEL,
             messages = perple_messages
         )
         case_result = response.choices[0].message.content

--- a/app/services/difficulty_service/difficulty_subgraph.py
+++ b/app/services/difficulty_service/difficulty_subgraph.py
@@ -5,7 +5,7 @@ from typing import Annotated, Sequence
 from langchain_core.messages import (
     BaseMessage,
 )
-from utils.model import anthropic, perple, perplexity_model, gpt4o
+from utils.model import anthropic, perple, PERPLEXITY_MODEL, gpt4o
 from services.difficulty_service.proto_researcher import protoResearcher, protoResearchDataset, protoResearchCollector
 
 

--- a/app/services/difficulty_service/guidelines.py
+++ b/app/services/difficulty_service/guidelines.py
@@ -2,7 +2,7 @@ from langchain.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnablePassthrough
 from langchain_core.output_parsers import StrOutputParser
 from utils.difficulty_prompt import seteukBasicBodyTop, seteukBasicIntroduction, seteukBasicCoclusion
-from utils.model import anthropic, perple, perplexity_model, gpt4o
+from utils.model import anthropic, perple, PERPLEXITY_MODEL, gpt4o
 import json
 
 

--- a/app/services/difficulty_service/proto_researcher.py
+++ b/app/services/difficulty_service/proto_researcher.py
@@ -1,5 +1,5 @@
 from utils.difficulty_prompt import protoResearcher_prompt
-from utils.model import anthropic, perple, perplexity_model, gpt4o
+from utils.model import anthropic, perple, PERPLEXITY_MODEL, gpt4o
 
 
 def protoResearcher(state):
@@ -16,7 +16,7 @@ def protoResearcher(state):
         "content": (prompt.user)}
     ]
     response = perple.chat.completions.create(
-                model = perplexity_model,
+                model = PERPLEXITY_MODEL,
                 messages = perple_messages
             )
     case_result = response.choices[0].message.content

--- a/app/services/difficulty_service_distil/case_researcher.py
+++ b/app/services/difficulty_service_distil/case_researcher.py
@@ -3,7 +3,7 @@ from langchain.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnablePassthrough
 from langchain_core.output_parsers import StrOutputParser
 from utils.difficulty_prompt_distil import  material_organizer, perplexity_prompt
-from utils.model import anthropic, perple, perplexity_model, gpt4o
+from utils.model import anthropic, perple, PERPLEXITY_MODEL, gpt4o
 from utils.utils import perple_process_result
 
 
@@ -38,7 +38,7 @@ def perplexity(state):
     
     try:
         response = perple.chat.completions.create(
-            model = perplexity_model,
+            model = PERPLEXITY_MODEL,
             messages = perple_messages
         )
         case_result = response.choices[0].message.content

--- a/app/services/difficulty_service_distil/guidelines.py
+++ b/app/services/difficulty_service_distil/guidelines.py
@@ -2,7 +2,7 @@ from langchain.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnablePassthrough
 from langchain_core.output_parsers import StrOutputParser
 from utils.difficulty_prompt_distil import seteukBasicBodyTop, seteukBasicIntroduction, seteukBasicCoclusion
-from utils.model import anthropic, perple, perplexity_model, gpt4o
+from utils.model import anthropic, perple, PERPLEXITY_MODEL, gpt4o
 import json
 
 

--- a/app/services/difficulty_service_distil2/case_researcher.py
+++ b/app/services/difficulty_service_distil2/case_researcher.py
@@ -3,7 +3,7 @@ from langchain.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnablePassthrough
 from langchain_core.output_parsers import StrOutputParser
 from utils.difficulty_prompt_distil2 import  material_organizer, perplexity_prompt
-from utils.model import anthropic, perple, perplexity_model, gpt4o
+from utils.model import anthropic, perple, PERPLEXITY_MODEL, gpt4o
 from utils.utils import perple_process_result
 
 
@@ -38,7 +38,7 @@ def perplexity(state):
     
     try:
         response = perple.chat.completions.create(
-            model = perplexity_model,
+            model = PERPLEXITY_MODEL,
             messages = perple_messages
         )
         case_result = response.choices[0].message.content

--- a/app/services/difficulty_service_distil2/difficulty_subgraph.py
+++ b/app/services/difficulty_service_distil2/difficulty_subgraph.py
@@ -5,7 +5,7 @@ from typing import Annotated, Sequence
 from langchain_core.messages import (
     BaseMessage,
 )
-from utils.model import anthropic, perple, perplexity_model, gpt4o
+from utils.model import anthropic, perple, PERPLEXITY_MODEL, gpt4o
 from services.difficulty_service_distil2.proto_researcher import protoResearcher, protoResearchDataset, protoResearchCollector
 
 

--- a/app/services/difficulty_service_distil2/guidelines.py
+++ b/app/services/difficulty_service_distil2/guidelines.py
@@ -2,7 +2,7 @@ from langchain.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnablePassthrough
 from langchain_core.output_parsers import StrOutputParser
 from utils.difficulty_prompt_distil2 import seteukBasicBodyTop, seteukBasicIntroduction, seteukBasicCoclusion
-from utils.model import anthropic, perple, perplexity_model, gpt4o
+from utils.model import anthropic, perple, PERPLEXITY_MODEL, gpt4o
 import json
 
 

--- a/app/services/difficulty_service_distil2/proto_researcher.py
+++ b/app/services/difficulty_service_distil2/proto_researcher.py
@@ -1,5 +1,5 @@
 from utils.difficulty_prompt_distil2 import protoResearcher_prompt
-from utils.model import anthropic, perple, perplexity_model, gpt4o
+from utils.model import anthropic, perple, PERPLEXITY_MODEL, gpt4o
 
 
 def protoResearcher(state):
@@ -16,7 +16,7 @@ def protoResearcher(state):
         "content": (prompt.user)}
     ]
     response = perple.chat.completions.create(
-                model = perplexity_model,
+                model = PERPLEXITY_MODEL,
                 messages = perple_messages
             )
     case_result = response.choices[0].message.content

--- a/app/services/submission_analyze/index.py
+++ b/app/services/submission_analyze/index.py
@@ -1,15 +1,9 @@
 import httpx
 import base64
 import json
-import anthropic
-import os
 from typing import Optional
-from dotenv import load_dotenv
 from utils.analyze_prompt import SYSTEM, USER
-
-load_dotenv(os.getenv("DOTENV_PATH", ".env"))
-
-ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
+from utils.model import ANTHROPIC_MODEL, anthropic_async
 
 
 async def download_pdf(presigned_url: str) -> bytes:
@@ -38,10 +32,8 @@ async def analyze_report(
         major=major or "",
     )
 
-    client = anthropic.AsyncAnthropic(api_key=ANTHROPIC_API_KEY)
-
-    message = await client.messages.create(
-        model="claude-sonnet-4-6",
+    message = await anthropic_async.messages.create(
+        model=ANTHROPIC_MODEL,
         max_tokens=4096,
         system=SYSTEM,
         output_config={

--- a/app/utils/model.py
+++ b/app/utils/model.py
@@ -2,8 +2,13 @@
 from langchain_anthropic import ChatAnthropic
 from langchain_openai import ChatOpenAI
 from openai import OpenAI
+from anthropic import AsyncAnthropic
 from dotenv import load_dotenv
 import os
+
+ANTHROPIC_MODEL = "claude-sonnet-4-6"
+OPENAI_MODEL = "gpt-4o"
+OPENAI_MINI_MODEL = "gpt-4o-mini"
 
 load_dotenv(os.getenv("DOTENV_PATH", ".env"))
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
@@ -12,20 +17,22 @@ PERPLEXITY_API_KEY = os.getenv('PERPLEXITY_API_KEY')
 
 
 anthropic = ChatAnthropic(
-    model="claude-sonnet-4-6",
+    model=ANTHROPIC_MODEL,
     max_tokens_to_sample=6000,
     temperature=0.8, 
     api_key = ANTHROPIC_API_KEY)
 
 gpt4o = ChatOpenAI(
-    model="gpt-4o",
+    model=OPENAI_MODEL,
     temperature=0.8,
     openai_api_key = OPENAI_API_KEY)
 
 gpt4o_mini = ChatOpenAI(
-    model="gpt-4o-mini",
+    model=OPENAI_MINI_MODEL,
     temperature=0.8,
     openai_api_key = OPENAI_API_KEY)
 
 perple = OpenAI(api_key = PERPLEXITY_API_KEY, base_url="https://api.perplexity.ai")
 perplexity_model = "sonar"
+
+anthropic_async = AsyncAnthropic(api_key=ANTHROPIC_API_KEY)

--- a/app/utils/model.py
+++ b/app/utils/model.py
@@ -9,6 +9,7 @@ import os
 ANTHROPIC_MODEL = "claude-sonnet-4-6"
 OPENAI_MODEL = "gpt-4o"
 OPENAI_MINI_MODEL = "gpt-4o-mini"
+PERPLEXITY_MODEL = "sonar"
 
 load_dotenv(os.getenv("DOTENV_PATH", ".env"))
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
@@ -33,6 +34,5 @@ gpt4o_mini = ChatOpenAI(
     openai_api_key = OPENAI_API_KEY)
 
 perple = OpenAI(api_key = PERPLEXITY_API_KEY, base_url="https://api.perplexity.ai")
-perplexity_model = "sonar"
 
 anthropic_async = AsyncAnthropic(api_key=ANTHROPIC_API_KEY)


### PR DESCRIPTION
## Summary

- LLM 모델명 상수(`ANTHROPIC_MODEL`, `OPENAI_MODEL`, `OPENAI_MINI_MODEL`, `PERPLEXITY_MODEL`)를 `app/utils/model.py` 상단에 정의
- `model.py`의 클라이언트 생성부와 `app/services/submission_analyze/index.py`가 하드코딩 문자열 대신 상수 참조 (submission_analyze는 `from utils.model import ANTHROPIC_MODEL`)

Fixes PT-1213.

## Why

모델명 `claude-sonnet-4-6`이 `model.py`(중앙 LangChain)와 `submission_analyze/index.py`(raw Anthropic SDK)에 **각각 하드코딩**돼 있어, 모델 교체 시 두 곳을 따로 고쳐야 하고 한 곳을 빠뜨리면 경로별로 모델이 달라지는 footgun이 있었다. 모델명을 `model.py` 한 곳으로 모아 단일 소스화했다.

## Behavior preservation

- **동작 동일**: 상수 값이 기존 하드코딩 값과 1:1 일치(`claude-sonnet-4-6`/`gpt-4o`/`gpt-4o-mini`/`sonar`). 런타임 동작 변화 없음.
- `model.py`가 export하던 `perplexity_model` 심볼 유지(값=`PERPLEXITY_MODEL`)라 `case_researcher` 등 기존 import 영향 없음.

## Test plan

- [x] `grep` — 하드코딩 모델 문자열이 `model.py` 외엔 없음 확인
- [x] 로컬 `docker build` + 컨테이너 부팅: `/docs` 200, 라우터 10개 로드