### PR TITLE
[PT-1272] [FEAT] keyword·submission·word-cloud HTTP 엔드포인트 Redis 스트림 전환

### DIFF
--- a/app/worker/consumer.py
+++ b/app/worker/consumer.py
@@ -6,7 +6,7 @@ import time
 import redis.asyncio as redis
 
 from worker import dispatch
-from worker.errors import InvalidPayload, UnsupportedJobType
+from worker.errors import InvalidPayload, JobFailed, UnsupportedJobType
 
 log = logging.getLogger("llm_worker")
 
@@ -154,7 +154,7 @@ class StreamConsumer:
         log.debug("payload requestId=%s %s", request_id, fields.get("payload"))
         try:
             payload = json.loads(fields.get("payload") or "{}")
-            result = await asyncio.to_thread(dispatch.dispatch, job_type, payload)
+            result = await dispatch.dispatch(job_type, payload)
             result_fields = {
                 "requestId": request_id,
                 "status": _SUCCEEDED,
@@ -197,6 +197,8 @@ class StreamConsumer:
 
 
 def _error_code(exc: Exception) -> str:
+    if isinstance(exc, JobFailed):
+        return exc.code  # 핸들러가 도메인 실패에 지정한 코드(WORD_CLOUD_FAILED 등)
     if isinstance(exc, UnsupportedJobType):
         return "UNSUPPORTED_JOB_TYPE"
     # payload 계약 위반(필수 필드 누락·미지원 값)과 JSON 파싱 실패는 입력 문제.

--- a/app/worker/dispatch.py
+++ b/app/worker/dispatch.py
@@ -1,15 +1,23 @@
+import asyncio
+
 from worker.errors import UnsupportedJobType
-from worker.handlers import seteuk
+from worker.handlers import keyword, seteuk, submission, wordcloud
 
 
 _HANDLERS = {
     "SETEUK_TOPIC_RECOMMEND": seteuk.handle_topic_recommend,
     "SETEUK_GUIDELINE_GENERATE": seteuk.handle_guideline_generate,
+    "KEYWORD_EXTRACTION": keyword.handle_keyword_extraction,
+    "SUBMISSION_ANALYSIS": submission.handle_submission_analysis,
+    "WORD_CLOUD": wordcloud.handle_word_cloud,
 }
 
 
-def dispatch(job_type: str, payload: dict) -> dict:
+async def dispatch(job_type: str, payload: dict) -> dict:
     handler = _HANDLERS.get(job_type)
     if handler is None:
         raise UnsupportedJobType(job_type)
-    return handler(payload)
+    # async 핸들러(비블로킹 LLM)는 이벤트 루프에서 await, sync 핸들러(블로킹 LLM/이미지)는 스레드로.
+    if asyncio.iscoroutinefunction(handler):
+        return await handler(payload)
+    return await asyncio.to_thread(handler, payload)

--- a/app/worker/errors.py
+++ b/app/worker/errors.py
@@ -7,3 +7,12 @@ class UnsupportedJobType(Exception):
 
 class InvalidPayload(Exception):
     """요청 payload 가 계약과 안 맞음 — 필수 필드 누락·미지원 값 등. 재시도해도 같다."""
+
+
+class JobFailed(Exception):
+    """도메인 처리 실패를 특정 errorCode 로 전달. 핸들러가 도메인 예외를 이걸로 감싸,
+    generic worker 는 도메인을 모른 채 code 만 결과에 싣는다."""
+
+    def __init__(self, code: str, message: str = ""):
+        self.code = code
+        super().__init__(message or code)

--- a/app/worker/handlers/keyword.py
+++ b/app/worker/handlers/keyword.py
@@ -1,0 +1,30 @@
+"""키워드 추출 jobType 처리기 — 요청 payload(dict) → 결과(dict).
+
+Java WordCloudAiAdapter 와 맞춘 입출력:
+- KEYWORD_EXTRACTION: {major?, subject?, subjectDetail?, guideline{introduction,body,conclusion}}
+  → {keywords:[{keyword, raw_weight}]}
+"""
+
+from services.keyword_extraction import extract_keywords
+from worker.errors import InvalidPayload
+
+
+def _require(payload: dict, key: str):
+    try:
+        return payload[key]
+    except KeyError:
+        raise InvalidPayload(f"missing field: {key!r}")
+
+
+def handle_keyword_extraction(payload: dict) -> dict:
+    guideline = _require(payload, "guideline")
+    info = " - ".join(
+        v for v in (payload.get("major"), payload.get("subject"), payload.get("subjectDetail")) if v
+    )
+    keywords = extract_keywords(
+        info=info,
+        introduction=_require(guideline, "introduction"),
+        body=_require(guideline, "body"),
+        conclusion=_require(guideline, "conclusion"),
+    )
+    return {"keywords": keywords}

--- a/app/worker/handlers/submission.py
+++ b/app/worker/handlers/submission.py
@@ -1,0 +1,29 @@
+"""제출물 분석 jobType 처리기 — 요청 payload(dict) → 결과(dict).
+
+Java SubmissionAnalysisAdapter 와 맞춘 입출력:
+- SUBMISSION_ANALYSIS: {presignedUrl, topic?, masterCategory?, subCategory?, department?, major?}
+  → {summary, review}
+
+원문 PDF 는 presignedUrl(S3) 로 워커가 직접 다운로드한다(메시지엔 본문 미포함).
+"""
+
+from services.submission_analyze import analyze_report
+from worker.errors import InvalidPayload
+
+
+def _require(payload: dict, key: str):
+    try:
+        return payload[key]
+    except KeyError:
+        raise InvalidPayload(f"missing field: {key!r}")
+
+
+async def handle_submission_analysis(payload: dict) -> dict:
+    return await analyze_report(
+        presigned_url=_require(payload, "presignedUrl"),
+        topic=payload.get("topic"),
+        master_category=payload.get("masterCategory"),
+        sub_category=payload.get("subCategory"),
+        department=payload.get("department"),
+        major=payload.get("major"),
+    )

--- a/app/worker/handlers/wordcloud.py
+++ b/app/worker/handlers/wordcloud.py
@@ -1,0 +1,44 @@
+"""워드클라우드 jobType 처리기 — 요청 payload(dict) → 결과(dict).
+
+Java WordCloudAiAdapter 와 맞춘 입출력:
+- WORD_CLOUD: {keywords[], font, color, mask, uploadUrl}
+  → PNG 을 생성해 uploadUrl(presigned PUT)로 업로드. 결과 본문 없음({}).
+
+이미지 바이너리는 스트림에 싣지 않는다("메시지엔 본문 미포함" 원칙) — Java 가 발급한
+presigned URL 로 워커가 직접 PUT 하고, 저장 위치 소유는 Java 가 유지한다.
+"""
+
+import requests
+
+from services.word_cloud import generate_word_cloud
+from worker.errors import InvalidPayload, JobFailed
+
+
+def _require(payload: dict, key: str):
+    try:
+        return payload[key]
+    except KeyError:
+        raise InvalidPayload(f"missing field: {key!r}")
+
+
+def _upload_png(url: str, data: bytes):
+    r = requests.put(url, data=data, headers={"Content-Type": "image/png"}, timeout=60)
+    r.raise_for_status()
+
+
+def handle_word_cloud(payload: dict) -> dict:
+    # 필드 검증은 try 밖 — InvalidPayload 가 catch-all 에 안 먹히게(saenggibu 패턴 동일).
+    keywords = _require(payload, "keywords")
+    if not keywords:  # 빈 키워드는 처리실패가 아니라 입력 계약 위반(원 라우터의 400 대응)
+        raise InvalidPayload("empty keywords")
+    font = _require(payload, "font")
+    color = _require(payload, "color")
+    mask = _require(payload, "mask")
+    upload_url = _require(payload, "uploadUrl")
+    try:
+        img_buffer = generate_word_cloud(keywords, font=font, color=color, mask=mask)
+        _upload_png(upload_url, img_buffer.getvalue())
+    except Exception as e:
+        # 워드클라우드는 LLM 을 안 쓰므로 기본 fallback(LLM_FAILED)이 부적합 — 전용 코드.
+        raise JobFailed("WORD_CLOUD_FAILED", str(e))
+    return {}

--- a/tests/test_keyword_submission_handlers.py
+++ b/tests/test_keyword_submission_handlers.py
@@ -1,0 +1,96 @@
+"""키워드추출·제출물분석 핸들러 순수 로직 테스트 — LLM 서비스는 monkeypatch 로 대체."""
+
+import pytest
+
+from worker import dispatch
+from worker.errors import InvalidPayload
+from worker.handlers import keyword, submission
+
+
+def test_keyword_info_assembly_and_shaping(monkeypatch):
+    captured = {}
+
+    def fake(info, introduction, body, conclusion):
+        captured.update(info=info, introduction=introduction, body=body, conclusion=conclusion)
+        return [{"keyword": "k1", "raw_weight": 7.2}]
+
+    monkeypatch.setattr(keyword, "extract_keywords", fake)
+    out = keyword.handle_keyword_extraction({
+        "major": "물리학", "subject": "물리", "subjectDetail": "역학",
+        "guideline": {"introduction": "서론", "body": "본론", "conclusion": "결론"},
+    })
+
+    assert captured["info"] == "물리학 - 물리 - 역학"       # major - subject - subjectDetail
+    assert (captured["introduction"], captured["body"], captured["conclusion"]) == ("서론", "본론", "결론")
+    assert out == {"keywords": [{"keyword": "k1", "raw_weight": 7.2}]}
+
+
+def test_keyword_info_skips_missing_parts(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(keyword, "extract_keywords",
+                        lambda info, **k: captured.update(info=info) or [])
+    keyword.handle_keyword_extraction({
+        "subject": "물리",  # major·subjectDetail 없음
+        "guideline": {"introduction": "i", "body": "b", "conclusion": "c"},
+    })
+    assert captured["info"] == "물리"                       # 빈 파트는 건너뜀
+
+
+def test_keyword_missing_guideline_raises():
+    with pytest.raises(InvalidPayload):
+        keyword.handle_keyword_extraction({"major": "x"})
+
+
+def test_keyword_missing_guideline_subfield_raises():
+    with pytest.raises(InvalidPayload):
+        keyword.handle_keyword_extraction({"guideline": {"introduction": "i", "body": "b"}})
+
+
+async def test_submission_param_mapping_and_passthrough(monkeypatch):
+    captured = {}
+
+    async def fake(presigned_url, topic, master_category, sub_category, department, major):
+        captured.update(presigned_url=presigned_url, topic=topic, master_category=master_category,
+                        sub_category=sub_category, department=department, major=major)
+        return {"summary": "요약", "review": "총평"}
+
+    monkeypatch.setattr(submission, "analyze_report", fake)
+    out = await submission.handle_submission_analysis({
+        "presignedUrl": "https://s3/x", "topic": "T", "masterCategory": "M",
+        "subCategory": "S", "department": "D", "major": "J",
+    })
+
+    assert captured == {"presigned_url": "https://s3/x", "topic": "T", "master_category": "M",
+                        "sub_category": "S", "department": "D", "major": "J"}
+    assert out == {"summary": "요약", "review": "총평"}
+
+
+async def test_submission_optional_fields_default_none(monkeypatch):
+    captured = {}
+
+    async def fake(presigned_url, **kw):
+        captured.update(presigned_url=presigned_url, **kw)
+        return {"summary": "", "review": ""}
+
+    monkeypatch.setattr(submission, "analyze_report", fake)
+    await submission.handle_submission_analysis({"presignedUrl": "https://s3/x"})
+    assert captured["topic"] is None and captured["major"] is None  # 선택 필드 미지정 → None
+
+
+async def test_submission_missing_url_raises():
+    with pytest.raises(InvalidPayload):
+        await submission.handle_submission_analysis({"topic": "T"})
+
+
+async def test_dispatch_routes_new_jobtypes(monkeypatch):
+    monkeypatch.setattr(keyword, "extract_keywords", lambda **k: [])
+
+    async def fake_analyze(presigned_url, **kw):
+        return {"summary": "", "review": ""}
+
+    monkeypatch.setattr(submission, "analyze_report", fake_analyze)
+
+    assert await dispatch.dispatch("KEYWORD_EXTRACTION", {
+        "guideline": {"introduction": "i", "body": "b", "conclusion": "c"},
+    }) == {"keywords": []}
+    assert await dispatch.dispatch("SUBMISSION_ANALYSIS", {"presignedUrl": "u"}) == {"summary": "", "review": ""}

--- a/tests/test_seteuk_handlers.py
+++ b/tests/test_seteuk_handlers.py
@@ -89,10 +89,10 @@ def test_guideline_empty_keywords(monkeypatch):
     assert out["referenceNews"] == []
 
 
-def test_dispatch_routes_and_rejects(monkeypatch):
+async def test_dispatch_routes_and_rejects(monkeypatch):
     monkeypatch.setattr(seteuk, "recommend_topics", lambda *a, **k: [])
-    assert dispatch.dispatch(
+    assert await dispatch.dispatch(
         "SETEUK_TOPIC_RECOMMEND", {"major": "x", "keyword": "k", "seteukDepth": "BASIC"}
     ) == {"topics": []}
     with pytest.raises(UnsupportedJobType):
-        dispatch.dispatch("NOPE", {})
+        await dispatch.dispatch("NOPE", {})

--- a/tests/test_wordcloud_handler.py
+++ b/tests/test_wordcloud_handler.py
@@ -1,0 +1,101 @@
+"""워드클라우드 핸들러 테스트 — 이미지 생성/업로드는 monkeypatch 로 대체."""
+
+from io import BytesIO
+
+import pytest
+
+from worker import dispatch
+from worker.errors import InvalidPayload, JobFailed
+from worker.handlers import wordcloud
+
+
+def _patch_generate(monkeypatch, png=b"PNGDATA"):
+    monkeypatch.setattr(wordcloud, "generate_word_cloud", lambda *a, **k: BytesIO(png))
+
+
+def test_generates_and_uploads_to_presigned_url(monkeypatch):
+    captured = {}
+    _patch_generate(monkeypatch, png=b"PNGBYTES")
+
+    def fake_put(url, data, headers, timeout):
+        captured.update(url=url, data=data, headers=headers)
+        return type("R", (), {"raise_for_status": lambda self: None})()
+
+    monkeypatch.setattr(wordcloud.requests, "put", fake_put)
+
+    out = wordcloud.handle_word_cloud({
+        "keywords": [{"keyword": "k", "raw_weight": 1.0}],
+        "font": 0, "color": 0, "mask": 0, "uploadUrl": "https://s3/put",
+    })
+
+    assert out == {}                                   # 결과 본문 없음
+    assert captured["url"] == "https://s3/put"
+    assert captured["data"] == b"PNGBYTES"             # 생성된 PNG bytes 를 PUT
+    assert captured["headers"]["Content-Type"] == "image/png"
+
+
+def test_generate_args_forwarded(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(wordcloud, "generate_word_cloud",
+                        lambda keywords, font, color, mask: captured.update(
+                            keywords=keywords, font=font, color=color, mask=mask) or BytesIO(b"x"))
+    monkeypatch.setattr(wordcloud, "_upload_png", lambda url, data: None)
+
+    wordcloud.handle_word_cloud({
+        "keywords": [{"keyword": "k", "raw_weight": 2.0}],
+        "font": 3, "color": 5, "mask": 1, "uploadUrl": "u",
+    })
+    assert captured == {"keywords": [{"keyword": "k", "raw_weight": 2.0}], "font": 3, "color": 5, "mask": 1}
+
+
+@pytest.mark.parametrize("missing", ["keywords", "font", "color", "mask", "uploadUrl"])
+def test_missing_field_raises_invalid_payload(missing):
+    payload = {"keywords": [{"keyword": "k", "raw_weight": 1.0}],
+               "font": 0, "color": 0, "mask": 0, "uploadUrl": "u"}
+    del payload[missing]
+    with pytest.raises(InvalidPayload):
+        wordcloud.handle_word_cloud(payload)
+
+
+def test_empty_keywords_is_invalid_payload_not_word_cloud_failed():
+    # 빈 키워드는 입력 계약 위반(INVALID_PAYLOAD) — 처리실패(WORD_CLOUD_FAILED) 아님
+    with pytest.raises(InvalidPayload):
+        wordcloud.handle_word_cloud({
+            "keywords": [], "font": 0, "color": 0, "mask": 0, "uploadUrl": "u",
+        })
+
+
+def test_upload_failure_wrapped_as_word_cloud_failed(monkeypatch):
+    _patch_generate(monkeypatch)
+
+    def boom(*a, **k):
+        raise RuntimeError("connection reset")
+
+    monkeypatch.setattr(wordcloud.requests, "put", boom)
+    with pytest.raises(JobFailed) as ei:
+        wordcloud.handle_word_cloud({
+            "keywords": [{"keyword": "k", "raw_weight": 1.0}],
+            "font": 0, "color": 0, "mask": 0, "uploadUrl": "u",
+        })
+    assert ei.value.code == "WORD_CLOUD_FAILED"        # LLM_FAILED fallback 아님
+
+
+def test_generate_failure_wrapped_as_word_cloud_failed(monkeypatch):
+    monkeypatch.setattr(wordcloud, "generate_word_cloud",
+                        lambda *a, **k: (_ for _ in ()).throw(ValueError("bad mask")))
+    with pytest.raises(JobFailed) as ei:
+        wordcloud.handle_word_cloud({
+            "keywords": [{"keyword": "k", "raw_weight": 1.0}],
+            "font": 0, "color": 0, "mask": 99, "uploadUrl": "u",
+        })
+    assert ei.value.code == "WORD_CLOUD_FAILED"
+
+
+async def test_dispatch_routes_word_cloud(monkeypatch):
+    _patch_generate(monkeypatch)
+    monkeypatch.setattr(wordcloud, "_upload_png", lambda url, data: None)
+    out = await dispatch.dispatch("WORD_CLOUD", {
+        "keywords": [{"keyword": "k", "raw_weight": 1.0}],
+        "font": 0, "color": 0, "mask": 0, "uploadUrl": "u",
+    })
+    assert out == {}


### PR DESCRIPTION
## Summary

- 마이폴리오 LLM 서버(FastAPI)의 남은 HTTP 엔드포인트 3개를 Redis 스트림 jobType 핸들러로 전환:
  - `KEYWORD_EXTRACTION` (`/keyword-extraction`) — Java WordCloudAiAdapter
  - `WORD_CLOUD` (`/word-cloud`) — Java WordCloudAiAdapter
  - `SUBMISSION_ANALYSIS` (`/submission-analysis`) — Java SubmissionAnalysisAdapter
- `dispatch.py`에 3개 jobType 등록, 기존 서비스 로직(`app/services/*`)은 그대로 재사용
- word-cloud PNG는 presigned PUT URL로 업로드해 스트림 메시지엔 바이너리를 싣지 않음

## Why

세특(PT-1235)은 스트림 워커로 전환됐으나, myfolio(Java)가 여전히 HTTP(RestClient)로 호출하는 LLM 엔드포인트 3개가 남아 운영 패턴이 갈렸다. 이들을 동일한 req/res 스트림 소비 방식으로 통일해 HTTP 홉을 제거한다. (설계 185303084)

## 워커 인프라 반입 (async 지원)

`submission` 분석 핸들러가 async(anthropic_async await)라, 동기만 지원하던 dev 워커에 async 지원을 함께 넣는다. 원래 이 인프라는 생기부 PR(#28)에 있었으나 **#28이 무기한 정지**되어 여기로 가져온다:

- `dispatch` 비동기화 — sync/async 핸들러 분기(`iscoroutinefunction`이면 await, 아니면 `to_thread`)
- `consumer`가 dispatch를 직접 await (기존 `to_thread(dispatch.dispatch)` 대체)
- `JobFailed` 예외 + `_error_code` 매핑 — word-cloud 전용 실패코드(`WORD_CLOUD_FAILED`)가 generic `LLM_FAILED`로 뭉개지지 않게

## Behavior preservation

- **입출력 스키마·서비스 로직 불변** — 진입점만 HTTP 라우터 → 워커 핸들러로 교체.
- **word-cloud 저장 소유 유지** — 기존엔 FastAPI가 PNG를 HTTP 응답 본문으로 반환하고 Java가 수령·저장했다. 전환 후에도 저장 위치 소유는 Java(presigned PUT URL 발급)가 유지하고, 워커는 그 URL로 PUT만 한다.
- **기존 HTTP 라우터는 제거하지 않고 병존**(전환기). 제거는 PT-1294.
- 기존 sync 핸들러(seteuk)는 async dispatch 하에서도 `to_thread`로 그대로 동작.

## Test plan

- [x] 신규 핸들러 단위 테스트 18개 (keyword/submission 8, word-cloud 10) — 입력 매핑·출력 shaping·계약위반(InvalidPayload)·업로드 실패(WORD_CLOUD_FAILED)·dispatch 라우팅
- [x] 전체 스위트 35 pass (seteuk 라우팅 테스트를 async dispatch에 맞춰 갱신 포함), 회귀 없음
- [ ] Java 어댑터 연동 후 스트림 e2e smoke (별건)

## Out of scope

- Java 측 발행/집계 어댑터 전환 (myfolio 레포) — word-cloud는 presigned PUT URL을 req에 발급하도록
- 기존 HTTP 라우터 제거 → PT-1294
- difficulty/proto 등 미전환 엔드포인트