### PR TITLE
[PT-1297] [HOTFIX] 블로킹 라우터 핸들러 async def→def (인스턴스당 동시성 1 해소)

### DIFF
--- a/app/routers/difficulty.py
+++ b/app/routers/difficulty.py
@@ -29,7 +29,7 @@ router = APIRouter(
 )
 
 @router.post("/topic")
-async def topic_gen(payload: TopicModel):
+def topic_gen(payload: TopicModel):
     major = payload.major
     keyword = payload.keyword 
     seteuk_depth = payload.seteuk_depth
@@ -59,7 +59,7 @@ async def topic_gen(payload: TopicModel):
 
 
 @router.post("/guidelines")
-async def protoGenerator(payload: GraphModel):
+def protoGenerator(payload: GraphModel):
     major = payload.major
     keyword = payload.keyword 
     topic = payload.topic

--- a/app/routers/difficulty_distil.py
+++ b/app/routers/difficulty_distil.py
@@ -31,7 +31,7 @@ router = APIRouter(
 )
 
 @router.post("/topic")
-async def topic_gen(payload: TopicModel):
+def topic_gen(payload: TopicModel):
     major = payload.major
     keyword = payload.keyword
     seteuk_depth = payload.seteuk_depth
@@ -61,7 +61,7 @@ async def topic_gen(payload: TopicModel):
 
 
 @router.post("/guidelines")
-async def protoGenerator(payload: GraphModel):
+def protoGenerator(payload: GraphModel):
     major = payload.major
     keyword = payload.keyword
     topic = payload.topic

--- a/app/routers/keyword.py
+++ b/app/routers/keyword.py
@@ -28,7 +28,7 @@ router = APIRouter()
 
 
 @router.post("/keyword-extraction")
-async def keyword_extraction(payload: KeywordExtractionModel):
+def keyword_extraction(payload: KeywordExtractionModel):
     """
     세특 콘텐츠에서 빈도 기반 raw_weight가 부여된 키워드를 추출하는 엔드포인트
 

--- a/app/routers/proto.py
+++ b/app/routers/proto.py
@@ -139,7 +139,7 @@ def llm_material_organizer(major, topic, context, model):
     return result_gpt
 
 @router.post("/proto")
-async def seteukProto(payload: RequestModel):
+def seteukProto(payload: RequestModel):
     # 테스트용 기본 응답 데이터 생성
     major = payload.major
     keyword = payload.keyword
@@ -169,7 +169,7 @@ async def seteukProto(payload: RequestModel):
         
 
 @router.post("/body")
-async def seteuk_body(payload: BodyModel):
+def seteuk_body(payload: BodyModel):
     topic = payload.topic
     proto = payload.proto
     case_result = payload.case_result
@@ -194,7 +194,7 @@ async def seteuk_body(payload: BodyModel):
     return {'response': answer}
 
 @router.post("/perplexity")
-async def perplexity(payload: RequestModel):
+def perplexity(payload: RequestModel):
     
     # 테스트용 기본 응답 데이터 생성
     major = payload.major

--- a/app/routers/word_cloud.py
+++ b/app/routers/word_cloud.py
@@ -26,7 +26,7 @@ router = APIRouter()
 
 
 @router.post("/word-cloud")
-async def create_word_cloud(payload: WordCloudRequestModel):
+def create_word_cloud(payload: WordCloudRequestModel):
     """
     키워드 리스트로부터 워드 클라우드 이미지를 생성하는 엔드포인트
 


### PR DESCRIPTION
## Summary

- 블로킹 작업을 하는 라우터 핸들러 9개를 `async def` → `def` 로 전환 (`difficulty.py`, `difficulty_distil.py`, `proto.py`, `keyword.py`, `word_cloud.py`).
- `await` 를 실제로 쓰는 `submission_analyze` 는 그대로 둠.

## Why

근본 원인은 **`async def` 핸들러가 동기 블로킹 호출을 `await` 없이 실행한 것**이다.

FastAPI/uvicorn 은 단일 이벤트 루프(워커 1개 = 스레드 1개) 위에서 요청을 협조적으로 스케줄링한다. 이 루프는 실행 중인 코루틴이 `await` 로 제어권을 넘길 때만 다른 요청으로 전환할 수 있다. 그런데 세특 핸들러는 `async def` 로 선언돼 **루프 위에서 직접 실행**되면서, 내부에서 `chain.invoke()` · LangGraph `run()` 같은 **동기 블로킹 호출을 `await` 없이** 돌렸다. 블로킹이 끝날 때까지(최장 ~90s) 코루틴이 양보하지 않으니 **이벤트 루프 전체가 그 시간 동안 얼어붙고**, 그 인스턴스는 다른 요청을 수락·처리하지 못한다. 인스턴스당 실질 동시성이 1 로 떨어지고, 부하가 몰리면 뒤 요청이 쌓이다 axios 600s 타임아웃(500)으로 떨어진다 — `/seteuk/auto-topic`·`/seteuk/auto-guidelines` 동시 타임아웃 알림이 그 증상이다.

이 결함은 AWS Lambda(요청 1건 = 인스턴스 1개) 시절엔 루프에 요청이 항상 1개뿐이라 드러나지 않다가, Cloud Run(인스턴스 1개가 다중 요청 동시 수용)으로 넘어오며 노출됐다.

해결은 두 갈래다. (a) `async def` → `def` 로 바꿔 FastAPI 가 핸들러를 anyio 스레드풀(기본 40)에서 돌리게 하거나, (b) `await chain.ainvoke()` 로 진짜 비동기화하는 것. 둘 다 블로킹을 이벤트 루프 밖으로 뺀다. (b)는 LangChain 체인·LangGraph·perplexity 클라이언트를 전부 async 로 재작성해야 해 핫픽스 범위를 넘으므로, 이번엔 (a)를 택했다. LLM 호출은 네트워크 대기(I/O-bound)라 대기 중 GIL 이 풀려, 스레드풀에서 요청들이 실제로 병렬 처리된다.

**실측 (동시요청 6개, 각 blocking ≈ 1s):**

| 핸들러 형태 | 6개 동시 처리 | 해석 |
|---|---|---|
| `async def` + 블로킹 (현행) | 6.03s | 이벤트 루프 직렬화 |
| `def` (스레드풀) I/O-bound | 1.01s | 병렬 — 이번 수정 효과 |
| `def` (스레드풀) CPU-bound | 4.02s | GIL 직렬화 (해당: `word_cloud` 뿐, 타임아웃 원인 아님) |

`async def`+블로킹이 `def` 전환으로 **6.03s → 1.01s(6배)** 로 떨어진다. CPU-bound 였다면 스레드로도 직렬화됐겠지만, seteuk LLM 호출은 I/O-bound 라 스레드풀이 유효하다.

## Behavior preservation

- **응답/입출력 계약 불변** — 시그니처의 `async ` 키워드만 제거했고 핸들러 로직·반환값·라우트 경로는 그대로다. FastAPI 는 `def`/`async def` 를 동일한 요청·응답으로 취급한다.
- **`submission_analyze` 미변경** — 유일하게 `await analyze_report(...)` 로 제대로 비동기라 손대지 않았다.

## Verification

| 항목 | 결과 |
|---|---|
| diff 범위 | 5개 파일, 9줄 (모두 `async def X(...)` → `def X(...)`, 로직 변경 0) |
| `python3 -m py_compile` (5개 파일) | 통과 |
| 남은 `async def` 핸들러 | `submission_analyze` 만 (의도대로) |
| 동시성 재현 | 위 Why 표 (async 6.03s → def 1.01s) — 최소 FastAPI 앱으로 실측 |

## Test plan

- [x] 대상 5개 파일 컴파일 통과
- [x] diff 가 `async ` 제거 9줄로만 한정됨을 확인
- [x] async vs def 동시성 실측 (6개 동시: 6.03s → 1.01s)
- [ ] 배포 후 `/seteukDifficulty_distil/topic`·`/guidelines` 정상 응답 smoke
- [ ] 부하 시 한 인스턴스가 다중 요청 병렬 처리(타임아웃 미발생) 확인
- [ ] `--concurrency` ↔ 스레드풀(40) ↔ 인스턴스 메모리 정렬값 점검, LLM provider rate limit 관측

## Out of scope

- `await ainvoke()` 로의 진짜 비동기화 (LangChain/LangGraph/perplexity async 재작성 — 근본 개선안 (b)).
- Cloud Run `--concurrency`/인스턴스 수/메모리 재조정 (별도 인프라 작업).
- `model.py` LLM 클라이언트 명시 timeout·재시도 부재 (별도 개선).
- 세특 동기 HTTP → Redis 스트림 워커(비동기 큐) 마이그레이션 (dev 진행 중).
