### PR TITLE
[PT-1318] [FEAT] GCP Cloud Logging용 JSON 구조화 로깅 (dev/prod 배포에서만)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,19 +3,23 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
-import logging
 import sys
 import os
 from contextlib import asynccontextmanager
 
 # 현재 디렉토리와 상위 디렉토리를 PYTHONPATH에 추가
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+# 로깅 설정을 라우터/워커 import보다 먼저 적용한다. 클라우드 배포(ENV=development/production)에서는
+# GCP Cloud Logging용 한 줄 JSON, 로컬에서는 평문 로그로 출력된다.
+from utils.logger import setup_logging, get_logger
+
+setup_logging()
+logger = get_logger("main")
+
 from routers import proto, difficulty, keyword, word_cloud, submission_analyze  # 라우터 가져오기
 from worker.config import WorkerConfig
 from worker.consumer import StreamConsumer
-
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
-logger = logging.getLogger("main")
 
 
 @asynccontextmanager

--- a/app/utils/logger.py
+++ b/app/utils/logger.py
@@ -1,0 +1,91 @@
+"""애플리케이션 로깅 설정.
+
+배포 환경(개발/운영 클라우드)에서는 GCP Cloud Logging이 자동으로 필드를 전개할 수 있도록
+stdout에 **한 줄 JSON**으로 로그를 출력한다. 로컬(ENV=local 또는 미설정)에서는 기존처럼
+사람이 읽기 쉬운 평문 로그를 유지한다.
+
+백엔드(Spring)와 키를 통일: severity / message / logger / timestamp.
+추가 컨텍스트 필드는 `extra=`로 넘기면 그대로 JSON 최상위 필드로 전개된다.
+
+    from utils.logger import get_logger
+    logger = get_logger(__name__)
+    logger.info("작업 완료", extra={"request_id": rid, "job_type": job, "duration_ms": ms})
+"""
+
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+
+from pythonjsonlogger.json import JsonFormatter
+
+# ENV 값이 아래에 속하면 JSON 구조화 로깅을 사용한다(클라우드 배포 상태).
+_CLOUD_ENVS = {"development", "production"}
+
+
+def _is_cloud_env() -> bool:
+    return os.getenv("ENV", "local").strip().lower() in _CLOUD_ENVS
+
+
+class GcpJsonFormatter(JsonFormatter):
+    """GCP Cloud Logging용 한 줄 JSON 포매터.
+
+    백엔드(Spring)와 동일한 키로 출력한다:
+    - severity: Python 로그 레벨명 (GCP LogSeverity와 호환)
+    - message: 포맷팅된 로그 메시지 (JsonFormatter 기본)
+    - logger: record.name
+    - timestamp: ISO8601 (UTC, 'Z' suffix)
+
+    `extra=`로 넘긴 커스텀 필드(request_id, job_type 등)와 예외 정보(exc_info)는
+    JsonFormatter가 자동으로 최상위 필드로 전개한다. 멀티라인 스택트레이스도
+    한 JSON 필드(exc_info 문자열)로 들어가 라인별로 쪼개지지 않는다.
+    """
+
+    def add_fields(self, log_record, record, message_dict):
+        super().add_fields(log_record, record, message_dict)
+        log_record["severity"] = record.levelname
+        log_record["logger"] = record.name
+        log_record["timestamp"] = (
+            datetime.fromtimestamp(record.created, timezone.utc)
+            .isoformat(timespec="milliseconds")
+            .replace("+00:00", "Z")
+        )
+
+
+def setup_logging(level: str | None = None) -> None:
+    """루트 로거와 uvicorn 로거를 환경에 맞는 핸들러/포매터로 재구성한다.
+
+    uvicorn은 기동 시 자체 로거(uvicorn/uvicorn.access/uvicorn.error)에 평문 핸들러를
+    붙이므로, 이 함수에서 해당 핸들러를 제거하고 루트로 전파시켜 포맷을 통일한다.
+    앱 import 시점(uvicorn의 로깅 설정 이후)에 호출되어야 우리 설정이 최종 적용된다.
+    """
+    level = (level or os.getenv("LOG_LEVEL", "INFO")).upper()
+
+    handler = logging.StreamHandler(sys.stdout)
+    if _is_cloud_env():
+        # ensure_ascii=False: 한글 메시지를 그대로 출력. message 키는 JsonFormatter 기본.
+        handler.setFormatter(GcpJsonFormatter(json_ensure_ascii=False))
+    else:
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+        )
+
+    root = logging.getLogger()
+    root.handlers = [handler]
+    root.setLevel(level)
+
+    # uvicorn 로거들이 자체 평문 핸들러로 직접 출력하지 않고 루트로 전파하도록 통일.
+    for name in ("uvicorn", "uvicorn.access", "uvicorn.error"):
+        lg = logging.getLogger(name)
+        lg.handlers = []
+        lg.propagate = True
+        lg.setLevel(level)
+
+
+def get_logger(name: str) -> logging.Logger:
+    """모듈용 로거를 반환한다. `print()` 대신 사용 권장.
+
+    from utils.logger import get_logger
+    logger = get_logger(__name__)
+    """
+    return logging.getLogger(name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ propcache==0.2.1
 pydantic==2.10.5
 pydantic_core==2.27.2
 python-dotenv==1.0.1
+python-json-logger==4.1.0
 PyYAML==6.0.2
 regex==2024.11.6
 requests==2.32.3


### PR DESCRIPTION
## Summary

- 배포 환경에서 애플리케이션 로그를 stdout에 **한 줄 JSON**으로 출력해 GCP Cloud Logging이 필드 단위로 전개·검색할 수 있게 함
- `app/utils/logger.py` 신규:
  - `GcpJsonFormatter` (`python-json-logger` 기반) — 백엔드(Spring)와 키 통일: `severity`/`message`/`logger`/`timestamp`(ISO8601 UTC)
  - `setup_logging()` — `ENV` 값으로 분기. `development`/`production`이면 JSON, `local`/미설정이면 기존 평문 유지
  - `get_logger()` — `print()` 대체용 헬퍼 (CLAUDE.md/LOGGING.md가 참조하던 심볼)
- `app/main.py`: `logging.basicConfig(...)` 제거 → 라우터/워커 import보다 먼저 `setup_logging()` 호출
- `requirements.txt`: `python-json-logger==4.1.0` 추가

Fixes PT-1318.

## Why

myfolio VM(dev·prod) 컨테이너 로그가 GCP Cloud Logging으로 수집되도록 인프라 구성이 끝났다. 백엔드(Spring)는 이미 한 줄 JSON으로 찍어 `severity`/`logger`/`message` 필드 검색이 되는데, LLM API는 uvicorn 기본 평문(`INFO: 127.0.0.1 - "GET / HTTP/1.1" 200 OK`)이라 인프라 regex로 severity까지만 추출된다. 앱이 JSON을 찍어야 요청 ID·작업 종류·에러 종류별 필드 검색이 가능하다. (인프라 과업 지시서 기반)

- `extra=`로 넘긴 컨텍스트 필드(`request_id`, `job_type`, `duration_ms` 등)는 JSON 최상위로 전개
- 예외는 멀티라인 스택이 라인별로 쪼개지지 않도록 단일 `exc_info` 문자열 필드로 (`logger.exception(...)` 지원)
- `ensure_ascii=False`로 한글 메시지 그대로 출력

## Behavior preservation

- **로컬 무변화**: `ENV`가 `local`이거나 미설정이면 기존 평문 포맷(`%(asctime)s %(levelname)s %(name)s %(message)s`) 유지. JSON은 클라우드 배포 상태에서만.
- **uvicorn 로그 통일**: uvicorn 자체 로거(`uvicorn`/`.access`/`.error`)의 평문 핸들러를 제거하고 루트로 전파시켜 access/error 로그도 동일 포맷으로 출력. uvicorn `configure_logging()`(Config 생성 시)보다 나중(앱 import 시)에 `setup_logging()`이 실행돼 최종 적용됨을 소스로 확인.
- 기존 로거 사용부(`llm_worker`, `main` 등)는 코드 변경 없이 그대로 JSON/평문에 반영 (propagate).
- `LOG_LEVEL` 환경변수로 레벨 오버라이드 가능(기본 INFO).

## Test plan

- [x] `ENV=production`: 워커/앱 로그가 `severity`/`message`/`logger`/`timestamp` + `extra` 필드 전개, 예외가 `exc_info` 단일 필드로 출력 확인
- [x] `ENV=production`: uvicorn `configure_logging()` 이후 `setup_logging()` 적용 순서 확인 → access/error 로그 JSON 출력 확인
- [x] `ENV=local`/미설정: 기존 평문 로그 유지 확인
- [ ] dev 배포 후 `gcloud logging read`로 `jsonPayload`에 `logger` 필드 전개 + `severity` 채워짐 확인

## Out of scope / 인프라 공유 필요

- **access log message 형식 변경**: JSON 전환 후 access 로그 `message`가 `127.0.0.1 - "GET /... HTTP/1.1" 200` 형태가 된다. 인프라 담당의 `/docs` 헬스체크 폴링 제외 필터 문자열 조정이 필요할 수 있음(과업 지시서 명시).
- `print()` → `logger` 전면 교체는 별건.